### PR TITLE
Bugfix/nft hash overflow

### DIFF
--- a/circuit/asset_delta.go
+++ b/circuit/asset_delta.go
@@ -454,7 +454,7 @@ func GetAssetDeltasAndNftDeltaFromWithdrawNft(
 	nftDelta = NftDeltaConstraints{
 		CreatorAccountIndex: types.ZeroInt,
 		OwnerAccountIndex:   types.ZeroInt,
-		NftContentHash:      types.ZeroInt,
+		NftContentHash:      [2]Variable{types.ZeroInt, types.ZeroInt},
 		CreatorTreasuryRate: types.ZeroInt,
 		CollectionId:        types.ZeroInt,
 	}
@@ -491,7 +491,9 @@ func GetNftDeltaFromFullExitNft(
 	isOwner := api.And(api.IsZero(api.Sub(txInfo.AccountIndex, nftBefore.OwnerAccountIndex)), flag)
 	creatorAccountIndex := api.Select(isOwner, types.ZeroInt, nftBefore.CreatorAccountIndex)
 	ownerAccountIndex := api.Select(isOwner, types.ZeroInt, nftBefore.OwnerAccountIndex)
-	nftContentHash := api.Select(isOwner, types.ZeroInt, nftBefore.NftContentHash)
+	nftContentHash := [2]Variable{}
+	nftContentHash[0] = api.Select(isOwner, types.ZeroInt, nftBefore.NftContentHash[0])
+	nftContentHash[1] = api.Select(isOwner, types.ZeroInt, nftBefore.NftContentHash[1])
 	creatorTreasuryRate := api.Select(isOwner, types.ZeroInt, nftBefore.CreatorTreasuryRate)
 	collectionId := api.Select(isOwner, types.ZeroInt, nftBefore.CollectionId)
 	nftDelta = NftDeltaConstraints{

--- a/circuit/block_constraints.go
+++ b/circuit/block_constraints.go
@@ -219,7 +219,7 @@ func GetZeroTxConstraint() TxConstraints {
 	// before
 	zeroTxConstraint.NftBefore = NftConstraints{
 		NftIndex:            0,
-		NftContentHash:      0,
+		NftContentHash:      [2]Variable{0, 0},
 		CreatorAccountIndex: 0,
 		OwnerAccountIndex:   0,
 		CreatorTreasuryRate: 0,

--- a/circuit/constraints_test.go
+++ b/circuit/constraints_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestTransactionConstraintsCounts(t *testing.T) {
+func TestTransactionConstraintsCount(t *testing.T) {
 	var txCircuit TxConstraints
 	r1cs, err := frontend.Compile(ecc.BN254, r1cs.NewBuilder, &txCircuit, frontend.IgnoreUnconstrainedInputs())
 	if err != nil {

--- a/circuit/nft_delta.go
+++ b/circuit/nft_delta.go
@@ -24,7 +24,7 @@ import (
 type NftDeltaConstraints struct {
 	CreatorAccountIndex Variable
 	OwnerAccountIndex   Variable
-	NftContentHash      Variable
+	NftContentHash      [2]Variable
 	CreatorTreasuryRate Variable
 	CollectionId        Variable
 }
@@ -33,7 +33,7 @@ func EmptyNftDeltaConstraints() NftDeltaConstraints {
 	return NftDeltaConstraints{
 		CreatorAccountIndex: types.ZeroInt,
 		OwnerAccountIndex:   types.ZeroInt,
-		NftContentHash:      types.ZeroInt,
+		NftContentHash:      [2]Variable{types.ZeroInt, types.ZeroInt},
 		CreatorTreasuryRate: types.ZeroInt,
 		CollectionId:        types.ZeroInt,
 	}

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -365,13 +365,22 @@ func VerifyTransaction(
 	newNftRoot := tx.NftRootBefore
 	api.AssertIsLessOrEqual(tx.NftBefore.NftIndex, LastNftIndex)
 	nftIndexMerkleHelper := NftIndexToMerkleHelper(api, tx.NftBefore.NftIndex)
-	nftNodeHash := poseidon.Poseidon(api,
+
+	isNotIpfsNftContentHash := api.IsZero(api.Sub(tx.NftBefore.NftContentHash[1], types.ZeroInt))
+	nftIpfsNodeHash := poseidon.Poseidon(api,
 		tx.NftBefore.CreatorAccountIndex,
 		tx.NftBefore.OwnerAccountIndex,
 		tx.NftBefore.NftContentHash[0],
 		tx.NftBefore.NftContentHash[1],
 		tx.NftBefore.CreatorTreasuryRate,
 		tx.NftBefore.CollectionId)
+	nftNotIpfsNodeHash := poseidon.Poseidon(api,
+		tx.NftBefore.CreatorAccountIndex,
+		tx.NftBefore.OwnerAccountIndex,
+		tx.NftBefore.NftContentHash[0],
+		tx.NftBefore.CreatorTreasuryRate,
+		tx.NftBefore.CollectionId)
+	nftNodeHash := api.Select(isNotIpfsNftContentHash, nftNotIpfsNodeHash, nftIpfsNodeHash)
 	// verify account merkle proof
 	types.VerifyMerkleProof(
 		api,
@@ -381,13 +390,21 @@ func VerifyTransaction(
 		tx.MerkleProofsNftBefore[:],
 		nftIndexMerkleHelper,
 	)
-	nftNodeHash = poseidon.Poseidon(api,
+
+	nftIpfsNodeHash = poseidon.Poseidon(api,
 		NftAfter.CreatorAccountIndex,
 		NftAfter.OwnerAccountIndex,
 		NftAfter.NftContentHash[0],
 		NftAfter.NftContentHash[1],
 		NftAfter.CreatorTreasuryRate,
 		NftAfter.CollectionId)
+	nftNotIpfsNodeHash = poseidon.Poseidon(api,
+		NftAfter.CreatorAccountIndex,
+		NftAfter.OwnerAccountIndex,
+		NftAfter.NftContentHash[0],
+		NftAfter.CreatorTreasuryRate,
+		NftAfter.CollectionId)
+	nftNodeHash = api.Select(isNotIpfsNftContentHash, nftNotIpfsNodeHash, nftIpfsNodeHash)
 	// update merkle proof
 	newNftRoot = types.UpdateMerkleProof(api, nftNodeHash, tx.MerkleProofsNftBefore[:], nftIndexMerkleHelper)
 	oldRoots[1] = api.Select(isEmptyTx, oldRoots[1], newNftRoot)

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -368,7 +368,8 @@ func VerifyTransaction(
 	nftNodeHash := poseidon.Poseidon(api,
 		tx.NftBefore.CreatorAccountIndex,
 		tx.NftBefore.OwnerAccountIndex,
-		tx.NftBefore.NftContentHash[:],
+		tx.NftBefore.NftContentHash[0],
+		tx.NftBefore.NftContentHash[1],
 		tx.NftBefore.CreatorTreasuryRate,
 		tx.NftBefore.CollectionId)
 	// verify account merkle proof
@@ -383,7 +384,8 @@ func VerifyTransaction(
 	nftNodeHash = poseidon.Poseidon(api,
 		NftAfter.CreatorAccountIndex,
 		NftAfter.OwnerAccountIndex,
-		NftAfter.NftContentHash[:],
+		NftAfter.NftContentHash[0],
+		NftAfter.NftContentHash[1],
 		NftAfter.CreatorTreasuryRate,
 		NftAfter.CollectionId)
 	// update merkle proof

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -368,7 +368,7 @@ func VerifyTransaction(
 	nftNodeHash := poseidon.Poseidon(api,
 		tx.NftBefore.CreatorAccountIndex,
 		tx.NftBefore.OwnerAccountIndex,
-		tx.NftBefore.NftContentHash,
+		tx.NftBefore.NftContentHash[:],
 		tx.NftBefore.CreatorTreasuryRate,
 		tx.NftBefore.CollectionId)
 	// verify account merkle proof
@@ -383,7 +383,7 @@ func VerifyTransaction(
 	nftNodeHash = poseidon.Poseidon(api,
 		NftAfter.CreatorAccountIndex,
 		NftAfter.OwnerAccountIndex,
-		NftAfter.NftContentHash,
+		NftAfter.NftContentHash[:],
 		NftAfter.CreatorTreasuryRate,
 		NftAfter.CollectionId)
 	// update merkle proof

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -367,17 +367,17 @@ func VerifyTransaction(
 	nftIndexMerkleHelper := NftIndexToMerkleHelper(api, tx.NftBefore.NftIndex)
 
 	isNotIpfsNftContentHash := api.IsZero(api.Sub(tx.NftBefore.NftContentHash[1], types.ZeroInt))
+	nftNotIpfsNodeHash := poseidon.Poseidon(api,
+		tx.NftBefore.CreatorAccountIndex,
+		tx.NftBefore.OwnerAccountIndex,
+		tx.NftBefore.NftContentHash[0],
+		tx.NftBefore.CreatorTreasuryRate,
+		tx.NftBefore.CollectionId)
 	nftIpfsNodeHash := poseidon.Poseidon(api,
 		tx.NftBefore.CreatorAccountIndex,
 		tx.NftBefore.OwnerAccountIndex,
 		tx.NftBefore.NftContentHash[0],
 		tx.NftBefore.NftContentHash[1],
-		tx.NftBefore.CreatorTreasuryRate,
-		tx.NftBefore.CollectionId)
-	nftNotIpfsNodeHash := poseidon.Poseidon(api,
-		tx.NftBefore.CreatorAccountIndex,
-		tx.NftBefore.OwnerAccountIndex,
-		tx.NftBefore.NftContentHash[0],
 		tx.NftBefore.CreatorTreasuryRate,
 		tx.NftBefore.CollectionId)
 	nftNodeHash := api.Select(isNotIpfsNftContentHash, nftNotIpfsNodeHash, nftIpfsNodeHash)
@@ -391,17 +391,18 @@ func VerifyTransaction(
 		nftIndexMerkleHelper,
 	)
 
+	isNotIpfsNftContentHash = api.IsZero(api.Sub(NftAfter.NftContentHash[1], types.ZeroInt))
+	nftNotIpfsNodeHash = poseidon.Poseidon(api,
+		NftAfter.CreatorAccountIndex,
+		NftAfter.OwnerAccountIndex,
+		NftAfter.NftContentHash[0],
+		NftAfter.CreatorTreasuryRate,
+		NftAfter.CollectionId)
 	nftIpfsNodeHash = poseidon.Poseidon(api,
 		NftAfter.CreatorAccountIndex,
 		NftAfter.OwnerAccountIndex,
 		NftAfter.NftContentHash[0],
 		NftAfter.NftContentHash[1],
-		NftAfter.CreatorTreasuryRate,
-		NftAfter.CollectionId)
-	nftNotIpfsNodeHash = poseidon.Poseidon(api,
-		NftAfter.CreatorAccountIndex,
-		NftAfter.OwnerAccountIndex,
-		NftAfter.NftContentHash[0],
 		NftAfter.CreatorTreasuryRate,
 		NftAfter.CollectionId)
 	nftNodeHash = api.Select(isNotIpfsNftContentHash, nftNotIpfsNodeHash, nftIpfsNodeHash)

--- a/circuit/types/constants.go
+++ b/circuit/types/constants.go
@@ -48,6 +48,8 @@ const (
 
 	PubDataBitsSizePerTx = 968 // registerZNS
 
+	NftContentHashBytesSize = 16
+
 	OfferSizePerAsset = 128
 
 	ChainId = 1

--- a/circuit/types/deposit_nft.go
+++ b/circuit/types/deposit_nft.go
@@ -17,6 +17,8 @@
 
 package types
 
+import "github.com/consensys/gnark/frontend"
+
 type DepositNftTx struct {
 	AccountIndex        int64
 	NftIndex            int64
@@ -31,7 +33,7 @@ type DepositNftTxConstraints struct {
 	AccountIndex        Variable
 	AccountNameHash     Variable
 	NftIndex            Variable
-	NftContentHash      Variable
+	NftContentHash      [2]Variable
 	CreatorAccountIndex Variable
 	CreatorTreasuryRate Variable
 	CollectionId        Variable
@@ -42,7 +44,7 @@ func EmptyDepositNftTxWitness() (witness DepositNftTxConstraints) {
 		AccountIndex:        ZeroInt,
 		AccountNameHash:     ZeroInt,
 		NftIndex:            ZeroInt,
-		NftContentHash:      ZeroInt,
+		NftContentHash:      [2]Variable{ZeroInt, ZeroInt},
 		CreatorAccountIndex: ZeroInt,
 		CreatorTreasuryRate: ZeroInt,
 		CollectionId:        ZeroInt,
@@ -54,7 +56,7 @@ func SetDepositNftTxWitness(tx *DepositNftTx) (witness DepositNftTxConstraints) 
 		AccountIndex:        tx.AccountIndex,
 		AccountNameHash:     tx.AccountNameHash,
 		NftIndex:            tx.NftIndex,
-		NftContentHash:      tx.NftContentHash,
+		NftContentHash:      [2]frontend.Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
 		CreatorAccountIndex: tx.CreatorAccountIndex,
 		CreatorTreasuryRate: tx.CreatorTreasuryRate,
 		CollectionId:        tx.CollectionId,

--- a/circuit/types/deposit_nft.go
+++ b/circuit/types/deposit_nft.go
@@ -17,8 +17,6 @@
 
 package types
 
-import "github.com/consensys/gnark/frontend"
-
 type DepositNftTx struct {
 	AccountIndex        int64
 	NftIndex            int64
@@ -56,7 +54,7 @@ func SetDepositNftTxWitness(tx *DepositNftTx) (witness DepositNftTxConstraints) 
 		AccountIndex:        tx.AccountIndex,
 		AccountNameHash:     tx.AccountNameHash,
 		NftIndex:            tx.NftIndex,
-		NftContentHash:      [2]frontend.Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
+		NftContentHash:      GetNftContentHashFromBytes(tx.NftContentHash),
 		CreatorAccountIndex: tx.CreatorAccountIndex,
 		CreatorTreasuryRate: tx.CreatorTreasuryRate,
 		CollectionId:        tx.CollectionId,

--- a/circuit/types/fullexit_nft.go
+++ b/circuit/types/fullexit_nft.go
@@ -36,7 +36,7 @@ type FullExitNftTxConstraints struct {
 	CreatorTreasuryRate    Variable
 	NftIndex               Variable
 	CollectionId           Variable
-	NftContentHash         Variable
+	NftContentHash         [2]Variable
 }
 
 func EmptyFullExitNftTxWitness() (witness FullExitNftTxConstraints) {
@@ -48,7 +48,7 @@ func EmptyFullExitNftTxWitness() (witness FullExitNftTxConstraints) {
 		CreatorTreasuryRate:    ZeroInt,
 		NftIndex:               ZeroInt,
 		CollectionId:           ZeroInt,
-		NftContentHash:         ZeroInt,
+		NftContentHash:         [2]Variable{ZeroInt, ZeroInt},
 	}
 }
 
@@ -61,7 +61,7 @@ func SetFullExitNftTxWitness(tx *FullExitNftTx) (witness FullExitNftTxConstraint
 		CreatorTreasuryRate:    tx.CreatorTreasuryRate,
 		NftIndex:               tx.NftIndex,
 		CollectionId:           tx.CollectionId,
-		NftContentHash:         tx.NftContentHash,
+		NftContentHash:         [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
 	}
 	return witness
 }
@@ -85,7 +85,9 @@ func VerifyFullExitNftTx(
 	isOwner := api.And(api.IsZero(api.Sub(tx.AccountIndex, nftBefore.OwnerAccountIndex)), flag)
 	IsVariableEqual(api, isOwner, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
 	IsVariableEqual(api, isOwner, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)
-	IsVariableEqual(api, isOwner, tx.NftContentHash, nftBefore.NftContentHash)
-	tx.NftContentHash = api.Select(isOwner, tx.NftContentHash, 0)
+	IsVariableEqual(api, isOwner, tx.NftContentHash[0], nftBefore.NftContentHash[0])
+	IsVariableEqual(api, isOwner, tx.NftContentHash[1], nftBefore.NftContentHash[1])
+	tx.NftContentHash[0] = api.Select(isOwner, tx.NftContentHash[0], 0)
+	tx.NftContentHash[1] = api.Select(isOwner, tx.NftContentHash[1], 0)
 	return pubData
 }

--- a/circuit/types/fullexit_nft.go
+++ b/circuit/types/fullexit_nft.go
@@ -61,7 +61,7 @@ func SetFullExitNftTxWitness(tx *FullExitNftTx) (witness FullExitNftTxConstraint
 		CreatorTreasuryRate:    tx.CreatorTreasuryRate,
 		NftIndex:               tx.NftIndex,
 		CollectionId:           tx.CollectionId,
-		NftContentHash:         [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
+		NftContentHash:         GetNftContentHashFromBytes(tx.NftContentHash),
 	}
 	return witness
 }

--- a/circuit/types/mint_nft.go
+++ b/circuit/types/mint_nft.go
@@ -38,7 +38,7 @@ type MintNftTxConstraints struct {
 	ToAccountIndex      Variable
 	ToAccountNameHash   Variable
 	NftIndex            Variable
-	NftContentHash      Variable
+	NftContentHash      [2]Variable
 	CreatorTreasuryRate Variable
 	GasAccountIndex     Variable
 	GasFeeAssetId       Variable
@@ -53,7 +53,7 @@ func EmptyMintNftTxWitness() (witness MintNftTxConstraints) {
 		ToAccountIndex:      ZeroInt,
 		ToAccountNameHash:   ZeroInt,
 		NftIndex:            ZeroInt,
-		NftContentHash:      ZeroInt,
+		NftContentHash:      [2]Variable{ZeroInt, ZeroInt},
 		CreatorTreasuryRate: ZeroInt,
 		GasAccountIndex:     ZeroInt,
 		GasFeeAssetId:       ZeroInt,
@@ -69,7 +69,7 @@ func SetMintNftTxWitness(tx *MintNftTx) (witness MintNftTxConstraints) {
 		ToAccountIndex:      tx.ToAccountIndex,
 		ToAccountNameHash:   tx.ToAccountNameHash,
 		NftIndex:            tx.NftIndex,
-		NftContentHash:      tx.NftContentHash,
+		NftContentHash:      [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
 		CreatorTreasuryRate: tx.CreatorTreasuryRate,
 		GasAccountIndex:     tx.GasAccountIndex,
 		GasFeeAssetId:       tx.GasFeeAssetId,
@@ -83,7 +83,7 @@ func SetMintNftTxWitness(tx *MintNftTx) (witness MintNftTxConstraints) {
 func ComputeHashFromMintNftTx(api API, tx MintNftTxConstraints, nonce Variable, expiredAt Variable) (hashVal Variable) {
 	return poseidon.Poseidon(api, ChainId, TxTypeMintNft, tx.CreatorAccountIndex, nonce, expiredAt,
 		tx.GasFeeAssetId, tx.GasFeeAssetAmount, tx.ToAccountIndex,
-		tx.CreatorTreasuryRate, tx.CollectionId, tx.ToAccountNameHash, tx.NftContentHash)
+		tx.CreatorTreasuryRate, tx.CollectionId, tx.ToAccountNameHash)
 }
 
 func VerifyMintNftTx(

--- a/circuit/types/mint_nft.go
+++ b/circuit/types/mint_nft.go
@@ -17,7 +17,9 @@
 
 package types
 
-import "github.com/consensys/gnark/std/hash/poseidon"
+import (
+	"github.com/consensys/gnark/std/hash/poseidon"
+)
 
 type MintNftTx struct {
 	CreatorAccountIndex int64
@@ -69,7 +71,7 @@ func SetMintNftTxWitness(tx *MintNftTx) (witness MintNftTxConstraints) {
 		ToAccountIndex:      tx.ToAccountIndex,
 		ToAccountNameHash:   tx.ToAccountNameHash,
 		NftIndex:            tx.NftIndex,
-		NftContentHash:      [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
+		NftContentHash:      GetNftContentHashFromBytes(tx.NftContentHash),
 		CreatorTreasuryRate: tx.CreatorTreasuryRate,
 		GasAccountIndex:     tx.GasAccountIndex,
 		GasFeeAssetId:       tx.GasFeeAssetId,

--- a/circuit/types/mint_nft.go
+++ b/circuit/types/mint_nft.go
@@ -104,7 +104,7 @@ func VerifyMintNftTx(
 	// account name hash
 	IsVariableEqual(api, flag, tx.ToAccountNameHash, accountsBefore[toAccount].AccountNameHash)
 	// content hash
-	isZero := api.IsZero(tx.NftContentHash)
+	isZero := api.Or(api.IsZero(tx.NftContentHash[0]), api.IsZero(tx.NftContentHash[1]))
 	IsVariableEqual(api, flag, isZero, 0)
 	// gas asset id
 	IsVariableEqual(api, flag, tx.GasFeeAssetId, accountsBefore[fromAccount].AssetsInfo[0].AssetId)

--- a/circuit/types/nft_constraints.go
+++ b/circuit/types/nft_constraints.go
@@ -24,7 +24,7 @@ import (
 
 type NftConstraints struct {
 	NftIndex            Variable
-	NftContentHash      Variable
+	NftContentHash      [2]Variable
 	CreatorAccountIndex Variable
 	OwnerAccountIndex   Variable
 	CreatorTreasuryRate Variable
@@ -40,7 +40,7 @@ func CheckEmptyNftNode(api API, flag Variable, nft NftConstraints) {
 }
 
 /*
-	SetNftWitness: set nft witness
+SetNftWitness: set nft witness
 */
 func SetNftWitness(nft *Nft) (witness NftConstraints, err error) {
 	if nft == nil {
@@ -50,7 +50,7 @@ func SetNftWitness(nft *Nft) (witness NftConstraints, err error) {
 	// set witness
 	witness = NftConstraints{
 		NftIndex:            nft.NftIndex,
-		NftContentHash:      nft.NftContentHash,
+		NftContentHash:      [2]Variable{nft.NftContentHash[:NftContentHashBytesSize], nft.NftContentHash[NftContentHashBytesSize:]},
 		CreatorAccountIndex: nft.CreatorAccountIndex,
 		OwnerAccountIndex:   nft.OwnerAccountIndex,
 		CreatorTreasuryRate: nft.CreatorTreasuryRate,

--- a/circuit/types/nft_constraints.go
+++ b/circuit/types/nft_constraints.go
@@ -51,7 +51,7 @@ func SetNftWitness(nft *Nft) (witness NftConstraints, err error) {
 	// set witness
 	witness = NftConstraints{
 		NftIndex:            nft.NftIndex,
-		NftContentHash:      [2]Variable{nft.NftContentHash[:NftContentHashBytesSize], nft.NftContentHash[NftContentHashBytesSize:]},
+		NftContentHash:      GetNftContentHashFromBytes(nft.NftContentHash),
 		CreatorAccountIndex: nft.CreatorAccountIndex,
 		OwnerAccountIndex:   nft.OwnerAccountIndex,
 		CreatorTreasuryRate: nft.CreatorTreasuryRate,

--- a/circuit/types/nft_constraints.go
+++ b/circuit/types/nft_constraints.go
@@ -32,7 +32,8 @@ type NftConstraints struct {
 }
 
 func CheckEmptyNftNode(api API, flag Variable, nft NftConstraints) {
-	IsVariableEqual(api, flag, nft.NftContentHash, ZeroInt)
+	IsVariableEqual(api, flag, nft.NftContentHash[0], ZeroInt)
+	IsVariableEqual(api, flag, nft.NftContentHash[1], ZeroInt)
 	IsVariableEqual(api, flag, nft.CreatorAccountIndex, ZeroInt)
 	IsVariableEqual(api, flag, nft.OwnerAccountIndex, ZeroInt)
 	IsVariableEqual(api, flag, nft.CreatorTreasuryRate, ZeroInt)

--- a/circuit/types/pubdata_helper.go
+++ b/circuit/types/pubdata_helper.go
@@ -54,7 +54,8 @@ func CollectPubDataFromDepositNft(api API, txInfo DepositNftTxConstraints) (pubD
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CreatorAccountIndex, AccountIndexBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CreatorTreasuryRate, CreatorTreasuryRateBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CollectionId, CollectionIdBitsSize, &currentOffset, pubData[:])
-	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash, HashBitsSize, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[0], HashBitsSize/2, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[1], HashBitsSize/2, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.AccountNameHash, HashBitsSize, &currentOffset, pubData[:])
 
 	for i := currentOffset; i < PubDataBitsSizePerTx; i++ {
@@ -120,7 +121,8 @@ func CollectPubDataFromMintNft(api API, txInfo MintNftTxConstraints) (pubData [P
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.GasFeeAssetAmount, PackedFeeBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CreatorTreasuryRate, CreatorTreasuryRateBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CollectionId, CollectionIdBitsSize, &currentOffset, pubData[:])
-	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash, HashBitsSize, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[0], HashBitsSize/2, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[1], HashBitsSize/2, &currentOffset, pubData[:])
 
 	for i := currentOffset; i < PubDataBitsSizePerTx; i++ {
 		pubData[i] = 0
@@ -191,7 +193,8 @@ func CollectPubDataFromWithdrawNft(api API, txInfo WithdrawNftTxConstraints) (pu
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.ToAddress, AddressBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.GasFeeAssetId, AssetIdBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.GasFeeAssetAmount, PackedFeeBitsSize, &currentOffset, pubData[:])
-	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash, HashBitsSize, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[0], HashBitsSize/2, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[1], HashBitsSize/2, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CreatorAccountNameHash, HashBitsSize, &currentOffset, pubData[:])
 
 	for i := currentOffset; i < PubDataBitsSizePerTx; i++ {
@@ -224,7 +227,8 @@ func CollectPubDataFromFullExitNft(api API, txInfo FullExitNftTxConstraints) (pu
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CollectionId, CollectionIdBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.AccountNameHash, HashBitsSize, &currentOffset, pubData[:])
 	copyLittleEndianSliceAndShiftOffset(api, txInfo.CreatorAccountNameHash, HashBitsSize, &currentOffset, pubData[:])
-	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash, HashBitsSize, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[0], HashBitsSize/2, &currentOffset, pubData[:])
+	copyLittleEndianSliceAndShiftOffset(api, txInfo.NftContentHash[1], HashBitsSize/2, &currentOffset, pubData[:])
 
 	for i := currentOffset; i < PubDataBitsSizePerTx; i++ {
 		pubData[i] = 0

--- a/circuit/types/pubdata_helper_test.go
+++ b/circuit/types/pubdata_helper_test.go
@@ -27,15 +27,12 @@ func TestCollectPubDataFromMintNftFieldOverflow(t *testing.T) {
 	var circuit, witness MintNftCircuit
 	circuit.TxInfo = MintNftTxConstraints{}
 
-	nftContentHash := "af6b80f7c6b8d2e5ce1cfa3a58c7c8530a7f75bc4f73569a8dcffbde3efc0753"
-
 	witness.TxInfo = MintNftTxConstraints{
 		CreatorAccountIndex: 4,
 		ToAccountIndex:      4,
 		ToAccountNameHash:   common.FromHex("1e0b0d8c4c69d2c061ced93a60fa9f08812dcc9e804efff7f445039d7834f1e53"),
 		NftIndex:            5,
-		NftContentHash: [2]frontend.Variable{common.FromHex(nftContentHash)[:NftContentHashBytesSize],
-			common.FromHex(nftContentHash)[NftContentHashBytesSize:]},
+		NftContentHash:      GetNftContentHashFromBytes(common.FromHex("af6b80f7c6b8d2e5ce1cfa3a58c7c8530a7f75bc4f73569a8dcffbde3efc0753")),
 		CreatorTreasuryRate: 0,
 		GasAccountIndex:     1,
 		GasFeeAssetId:       0,
@@ -73,15 +70,12 @@ func TestCollectPubDataFromMintNft(t *testing.T) {
 	var circuit, witness MintNftCircuit
 	circuit.TxInfo = MintNftTxConstraints{}
 
-	nftContentHash := "0d736736cea2105c1eae36c240a2ebe03e22d2393b4b7edc2fe5a921a5d66db2"
-
 	witness.TxInfo = MintNftTxConstraints{
 		CreatorAccountIndex: 4,
 		ToAccountIndex:      4,
 		ToAccountNameHash:   common.FromHex("1e0b0d8c4c69d2c061ced93a60fa9f08812dcc9e804efff7f445039d7834f1e5"),
 		NftIndex:            5,
-		NftContentHash: [2]frontend.Variable{common.FromHex(nftContentHash)[0:16],
-			common.FromHex(nftContentHash)[16:]},
+		NftContentHash:      GetNftContentHashFromBytes(common.FromHex("0d736736cea2105c1eae36c240a2ebe03e22d2393b4b7edc2fe5a921a5d66db2")),
 		CreatorTreasuryRate: 0,
 		GasAccountIndex:     1,
 		GasFeeAssetId:       0,

--- a/circuit/types/pubdata_helper_test.go
+++ b/circuit/types/pubdata_helper_test.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/backend"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+	"github.com/ethereum/go-ethereum/common"
+	"testing"
+)
+
+type MintNftCircuit struct {
+	ExpectedResult [PubDataBitsSizePerTx]frontend.Variable
+	TxInfo         MintNftTxConstraints
+}
+
+func (circuit MintNftCircuit) Define(api frontend.API) error {
+	pubData := CollectPubDataFromMintNft(api, circuit.TxInfo)
+
+	for i := range pubData {
+		api.AssertIsEqual(pubData[i], circuit.ExpectedResult[i])
+	}
+	return nil
+}
+
+func TestCollectPubDataFromMintNftFieldOverflow(t *testing.T) {
+	var circuit, witness MintNftCircuit
+	circuit.TxInfo = MintNftTxConstraints{}
+
+	nftContentHash := "af6b80f7c6b8d2e5ce1cfa3a58c7c8530a7f75bc4f73569a8dcffbde3efc0753"
+
+	witness.TxInfo = MintNftTxConstraints{
+		CreatorAccountIndex: 4,
+		ToAccountIndex:      4,
+		ToAccountNameHash:   common.FromHex("1e0b0d8c4c69d2c061ced93a60fa9f08812dcc9e804efff7f445039d7834f1e53"),
+		NftIndex:            5,
+		NftContentHash: [2]frontend.Variable{common.FromHex(nftContentHash)[:NftContentHashBytesSize],
+			common.FromHex(nftContentHash)[NftContentHashBytesSize:]},
+		CreatorTreasuryRate: 0,
+		GasAccountIndex:     1,
+		GasFeeAssetId:       0,
+		GasFeeAssetAmount:   32010,
+		CollectionId:        0,
+		ExpiredAt:           1673624416687,
+	}
+	pubData := common.Hex2Bytes("070000000400000004000000000500007d0a00000000af6b80f7c6b8d2e5ce1cfa3a58c7c8530a7f75bc4f73569a8dcffbde3efc075300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+	witness.ExpectedResult = [968]frontend.Variable{}
+
+	j := 0
+	for i := 0; i <= 960; i = i + 8 {
+		witness.ExpectedResult[i] = pubData[j] >> 7 & 1
+		witness.ExpectedResult[i+1] = pubData[j] >> 6 & 1
+		witness.ExpectedResult[i+2] = pubData[j] >> 5 & 1
+		witness.ExpectedResult[i+3] = pubData[j] >> 4 & 1
+		witness.ExpectedResult[i+4] = pubData[j] >> 3 & 1
+		witness.ExpectedResult[i+5] = pubData[j] >> 2 & 1
+		witness.ExpectedResult[i+6] = pubData[j] >> 1 & 1
+		witness.ExpectedResult[i+7] = pubData[j] >> 0 & 1
+		j = j + 1
+	}
+
+	assert := test.NewAssert(t)
+	assert.SolvingSucceeded(
+		&circuit,
+		&witness,
+		test.WithBackends(backend.GROTH16),
+		test.WithCurves(ecc.BN254),
+		test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()),
+	)
+}
+
+func TestCollectPubDataFromMintNft(t *testing.T) {
+	var circuit, witness MintNftCircuit
+	circuit.TxInfo = MintNftTxConstraints{}
+
+	nftContentHash := "0d736736cea2105c1eae36c240a2ebe03e22d2393b4b7edc2fe5a921a5d66db2"
+
+	witness.TxInfo = MintNftTxConstraints{
+		CreatorAccountIndex: 4,
+		ToAccountIndex:      4,
+		ToAccountNameHash:   common.FromHex("1e0b0d8c4c69d2c061ced93a60fa9f08812dcc9e804efff7f445039d7834f1e5"),
+		NftIndex:            5,
+		NftContentHash: [2]frontend.Variable{common.FromHex(nftContentHash)[0:16],
+			common.FromHex(nftContentHash)[16:]},
+		CreatorTreasuryRate: 0,
+		GasAccountIndex:     1,
+		GasFeeAssetId:       0,
+		GasFeeAssetAmount:   32010,
+		CollectionId:        0,
+		ExpiredAt:           1673624416687,
+	}
+	pubData := common.Hex2Bytes("070000000400000004000000000500007d0a000000000d736736cea2105c1eae36c240a2ebe03e22d2393b4b7edc2fe5a921a5d66db200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+	witness.ExpectedResult = [968]frontend.Variable{}
+
+	j := 0
+	for i := 0; i <= 960; i = i + 8 {
+		witness.ExpectedResult[i] = pubData[j] >> 7 & 1
+		witness.ExpectedResult[i+1] = pubData[j] >> 6 & 1
+		witness.ExpectedResult[i+2] = pubData[j] >> 5 & 1
+		witness.ExpectedResult[i+3] = pubData[j] >> 4 & 1
+		witness.ExpectedResult[i+4] = pubData[j] >> 3 & 1
+		witness.ExpectedResult[i+5] = pubData[j] >> 2 & 1
+		witness.ExpectedResult[i+6] = pubData[j] >> 1 & 1
+		witness.ExpectedResult[i+7] = pubData[j] >> 0 & 1
+		j = j + 1
+	}
+
+	assert := test.NewAssert(t)
+	assert.SolvingSucceeded(
+		&circuit,
+		&witness,
+		test.WithBackends(backend.GROTH16),
+		test.WithCurves(ecc.BN254),
+		test.WithCompileOpts(frontend.IgnoreUnconstrainedInputs()),
+	)
+}

--- a/circuit/types/utils.go
+++ b/circuit/types/utils.go
@@ -19,6 +19,7 @@ package types
 
 import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa"
+	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/algebra/twistededwards"
 	eddsaConstraints "github.com/consensys/gnark/std/signature/eddsa"
 )
@@ -59,4 +60,14 @@ func copyLittleEndianSliceAndShiftOffset(api API, txField Variable, txFiledBitsS
 	txFiledBits := api.ToBinary(txField, txFiledBitsSize)
 	CopyLittleEndianSlice(pubData[*currentOffset:*currentOffset+txFiledBitsSize], txFiledBits)
 	*currentOffset += txFiledBitsSize
+}
+
+func GetNftContentHashFromBytes(hash []byte) [2]frontend.Variable {
+	var nftContentHash [2]Variable
+	if len(hash) >= NftContentHashBytesSize {
+		nftContentHash = [2]Variable{hash[:NftContentHashBytesSize], hash[NftContentHashBytesSize:]}
+	} else {
+		nftContentHash = [2]Variable{hash[:], ZeroInt}
+	}
+	return nftContentHash
 }

--- a/circuit/types/withdraw_nft.go
+++ b/circuit/types/withdraw_nft.go
@@ -70,7 +70,7 @@ func SetWithdrawNftTxWitness(tx *WithdrawNftTx) (witness WithdrawNftTxConstraint
 		CreatorAccountNameHash: tx.CreatorAccountNameHash,
 		CreatorTreasuryRate:    tx.CreatorTreasuryRate,
 		NftIndex:               tx.NftIndex,
-		NftContentHash:         [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
+		NftContentHash:         GetNftContentHashFromBytes(tx.NftContentHash),
 		ToAddress:              tx.ToAddress,
 		GasAccountIndex:        tx.GasAccountIndex,
 		GasFeeAssetId:          tx.GasFeeAssetId,

--- a/circuit/types/withdraw_nft.go
+++ b/circuit/types/withdraw_nft.go
@@ -109,7 +109,8 @@ func VerifyWithdrawNftTx(
 	IsVariableEqual(api, flag, tx.CreatorAccountIndex, nftBefore.CreatorAccountIndex)
 	IsVariableEqual(api, flag, tx.CreatorTreasuryRate, nftBefore.CreatorTreasuryRate)
 	IsVariableEqual(api, flag, tx.AccountIndex, nftBefore.OwnerAccountIndex)
-	IsVariableEqual(api, flag, tx.NftContentHash, nftBefore.NftContentHash)
+	IsVariableEqual(api, flag, tx.NftContentHash[0], nftBefore.NftContentHash[0])
+	IsVariableEqual(api, flag, tx.NftContentHash[1], nftBefore.NftContentHash[1])
 	// have enough assets
 	tx.GasFeeAssetAmount = UnpackFee(api, tx.GasFeeAssetAmount)
 	IsVariableLessOrEqual(api, flag, tx.GasFeeAssetAmount, accountsBefore[fromAccount].AssetsInfo[0].Balance)

--- a/circuit/types/withdraw_nft.go
+++ b/circuit/types/withdraw_nft.go
@@ -39,7 +39,7 @@ type WithdrawNftTxConstraints struct {
 	CreatorAccountNameHash Variable
 	CreatorTreasuryRate    Variable
 	NftIndex               Variable
-	NftContentHash         Variable
+	NftContentHash         [2]Variable
 	ToAddress              Variable
 	GasAccountIndex        Variable
 	GasFeeAssetId          Variable
@@ -54,7 +54,7 @@ func EmptyWithdrawNftTxWitness() (witness WithdrawNftTxConstraints) {
 		CreatorAccountNameHash: ZeroInt,
 		CreatorTreasuryRate:    ZeroInt,
 		NftIndex:               ZeroInt,
-		NftContentHash:         ZeroInt,
+		NftContentHash:         [2]Variable{ZeroInt, ZeroInt},
 		ToAddress:              ZeroInt,
 		GasAccountIndex:        ZeroInt,
 		GasFeeAssetId:          ZeroInt,
@@ -70,7 +70,7 @@ func SetWithdrawNftTxWitness(tx *WithdrawNftTx) (witness WithdrawNftTxConstraint
 		CreatorAccountNameHash: tx.CreatorAccountNameHash,
 		CreatorTreasuryRate:    tx.CreatorTreasuryRate,
 		NftIndex:               tx.NftIndex,
-		NftContentHash:         tx.NftContentHash,
+		NftContentHash:         [2]Variable{tx.NftContentHash[:NftContentHashBytesSize], tx.NftContentHash[NftContentHashBytesSize:]},
 		ToAddress:              tx.ToAddress,
 		GasAccountIndex:        tx.GasAccountIndex,
 		GasFeeAssetId:          tx.GasFeeAssetId,

--- a/circuit/utils.go
+++ b/circuit/utils.go
@@ -60,7 +60,8 @@ func SelectNftDeltas(
 ) (deltaRes NftDeltaConstraints) {
 	deltaRes.CreatorAccountIndex = api.Select(flag, delta.CreatorAccountIndex, deltaCheck.CreatorAccountIndex)
 	deltaRes.OwnerAccountIndex = api.Select(flag, delta.OwnerAccountIndex, deltaCheck.OwnerAccountIndex)
-	deltaRes.NftContentHash = api.Select(flag, delta.NftContentHash, deltaCheck.NftContentHash)
+	deltaRes.NftContentHash[0] = api.Select(flag, delta.NftContentHash[0], deltaCheck.NftContentHash[0])
+	deltaRes.NftContentHash[1] = api.Select(flag, delta.NftContentHash[1], deltaCheck.NftContentHash[1])
 	deltaRes.CreatorTreasuryRate = api.Select(flag, delta.CreatorTreasuryRate, deltaCheck.CreatorTreasuryRate)
 	deltaRes.CollectionId = api.Select(flag, delta.CollectionId, deltaCheck.CollectionId)
 	return deltaRes

--- a/wasm/txtypes/create_collection.go
+++ b/wasm/txtypes/create_collection.go
@@ -96,6 +96,20 @@ type CreateCollectionTxInfo struct {
 	ExpiredAt         int64
 	Nonce             int64
 	Sig               []byte
+	MetaData          *CollectionMetaData
+}
+
+type CollectionMetaData struct {
+	LogoImage         string
+	FeaturedImage     string
+	BannerImage       string
+	Shortname         string
+	ExternalLink      string
+	TwitterUserName   string
+	InstagramUserName string
+	TelegramLink      string
+	DiscordLink       string
+	CategoryID        int64
 }
 
 func (txInfo *CreateCollectionTxInfo) Validate() error {

--- a/wasm/txtypes/mint_nft.go
+++ b/wasm/txtypes/mint_nft.go
@@ -140,9 +140,9 @@ func (txInfo *MintNftTxInfo) Validate() error {
 	}
 
 	// NftContentHash
-	if !IsValidHash(txInfo.NftContentHash) {
-		return ErrNftContentHashInvalid
-	}
+	//if !IsValidHash(txInfo.NftContentHash) {
+	//	return ErrNftContentHashInvalid
+	//}
 
 	// NftCollectionId
 	if txInfo.NftCollectionId < minCollectionId {

--- a/wasm/txtypes/mint_nft.go
+++ b/wasm/txtypes/mint_nft.go
@@ -105,6 +105,16 @@ type MintNftTxInfo struct {
 	ExpiredAt           int64
 	Nonce               int64
 	Sig                 []byte
+	MetaData            *NftMetaData
+	IpnsName            string
+	IpnsId              string
+}
+
+type NftMetaData struct {
+	Image       string
+	Name        string
+	Description string
+	Attributes  string
 }
 
 func (txInfo *MintNftTxInfo) Validate() error {
@@ -233,8 +243,7 @@ func (txInfo *MintNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	}
 	msgHash = Poseidon(ChainId, TxTypeMintNft, txInfo.CreatorAccountIndex, txInfo.Nonce, txInfo.ExpiredAt,
 		txInfo.GasFeeAssetId, packedFee, txInfo.ToAccountIndex, txInfo.CreatorTreasuryRate, txInfo.NftCollectionId,
-		ffmath.Mod(new(big.Int).SetBytes(common.FromHex(txInfo.ToAccountNameHash)), curve.Modulus),
-		ffmath.Mod(new(big.Int).SetBytes(common.FromHex(txInfo.NftContentHash)), curve.Modulus))
+		ffmath.Mod(new(big.Int).SetBytes(common.FromHex(txInfo.ToAccountNameHash)), curve.Modulus))
 	return msgHash, nil
 }
 

--- a/wasm/txtypes/utils.go
+++ b/wasm/txtypes/utils.go
@@ -81,7 +81,7 @@ func PaddingAddressToBytes32(addr string) []byte {
 }
 
 /*
-	ToPackedAmount: convert big int to 40 bit, 5 bits for 10^x, 35 bits for a * 10^x
+ToPackedAmount: convert big int to 40 bit, 5 bits for 10^x, 35 bits for a * 10^x
 */
 func ToPackedAmount(amount *big.Int) (res int64, err error) {
 	return util.ToPackedAmount(amount)
@@ -92,7 +92,7 @@ func CleanPackedAmount(amount *big.Int) (nAmount *big.Int, err error) {
 }
 
 /*
-	ToPackedFee: convert big int to 16 bit, 5 bits for 10^x, 11 bits for a * 10^x
+ToPackedFee: convert big int to 16 bit, 5 bits for 10^x, 11 bits for a * 10^x
 */
 func ToPackedFee(amount *big.Int) (res int64, err error) {
 	return util.ToPackedFee(amount)
@@ -175,6 +175,11 @@ func FromHexStrToFr(s string) (*fr.Element, error) {
 	if !success {
 		return nil, errors.New("not a valid hex str")
 	}
+	return FromBigIntToFr(n), nil
+}
+
+func FromBytesToFr(b []byte) (*fr.Element, error) {
+	n := new(big.Int).SetBytes(b)
 	return FromBigIntToFr(n), nil
 }
 


### PR DESCRIPTION
### Description

`NftContentHash` value may exceed number `p` which causes number overflow and error result.

### Changes

Notable changes:
* Split `NftContentHash` into 2 16-byte variable and remove it from Poseidon hash calculation for wasm.